### PR TITLE
[Fix] 인기 제품 redis 관련 기능 수정

### DIFF
--- a/src/main/java/kr/or/connect/reservation/domain/product/InMemoryProductDto.java
+++ b/src/main/java/kr/or/connect/reservation/domain/product/InMemoryProductDto.java
@@ -8,6 +8,7 @@ import lombok.ToString;
 
 import java.io.Serializable;
 import java.time.LocalDate;
+import java.util.Objects;
 
 @Getter @Setter @ToString
 public class InMemoryProductDto implements Serializable, Comparable<InMemoryProductDto> {
@@ -61,5 +62,18 @@ public class InMemoryProductDto implements Serializable, Comparable<InMemoryProd
             return this.totalReservedCount.compareTo(o.totalReservedCount);
         }
         return 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(productId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        InMemoryProductDto that = (InMemoryProductDto) o;
+        return Objects.equals(productId, that.productId);
     }
 }

--- a/src/main/java/kr/or/connect/reservation/domain/product/ProductService.java
+++ b/src/main/java/kr/or/connect/reservation/domain/product/ProductService.java
@@ -161,8 +161,13 @@ public class ProductService {
 		return ProductSeatScheduleResponse.of(seatSchedule, place);
 	}
 
+	/**
+	 * DB(local cache, redis 등 적용) 에서 인기 데이터 조회
+	 * @param startPage
+	 * @return
+	 */
 	public List<PopularProductResponse> getRealTimePopularProduct(Integer startPage) {
-		List<InMemoryProductDto> inMemoryProductDto = redisPopularProduct.getInMemoryProductDto();
+		List<InMemoryProductDto> inMemoryProductDto = redisPopularProduct.getProductDtos();
 
 		int offset = startPage * PRODUCT_PAGE_SIZE;
 		int limit = PRODUCT_PAGE_SIZE;
@@ -182,7 +187,7 @@ public class ProductService {
 				.map(PopularProductResponse::of)
 				.collect(Collectors.toList());
 
-//		local thread 코드
+//		local cahe 코드
 //		if (inMemoryPopularProduct.isEmpty()) {
 //			log.info("get popular product from DB");
 //

--- a/src/main/java/kr/or/connect/reservation/domain/product/RedisPopularProduct.java
+++ b/src/main/java/kr/or/connect/reservation/domain/product/RedisPopularProduct.java
@@ -9,10 +9,7 @@ import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Component
@@ -22,77 +19,96 @@ public class RedisPopularProduct {
     private final ProductSeatScheduleRepository productSeatScheduleRepository;
     private final RedissonClient redissonClient;
 
+    /**
+     *  기동 시 Redis에 cache warmup
+     */
     @PostConstruct
     public void initialize() {
         List<PopularProductDto> popularProductDtos = productSeatScheduleRepository
                 .findAllPopularProductByReservation();
 
-        List<InMemoryProductDto> inMemoryProductDtos = popularProductDtos.stream()
+        List<InMemoryProductDto> productDtos = popularProductDtos.stream()
                 .map(InMemoryProductDto::of)
                 .collect(Collectors.toList());
 
         RSortedSet<InMemoryProductDto> redissonClientSortedSet = redissonClient.getSortedSet("popularProducts");
-        Collection<InMemoryProductDto> collection = redissonClientSortedSet.readAll();
+        redissonClientSortedSet.clear(); // 기존 데이터 삭제 후
 
-        for (InMemoryProductDto inMemoryProductDto : inMemoryProductDtos) {
-            boolean isDuplicated = false;
-            for (InMemoryProductDto memoryProductDto : collection) {
-                if (Objects.equals(inMemoryProductDto.getProductId(), memoryProductDto.getProductId())) {
-                    isDuplicated = true;
-                    break;
-                }
-            }
+        // 기존 데이터를 가져와 Set으로 중복 제거
+        Set<InMemoryProductDto> existingSet = new HashSet<>(redissonClientSortedSet.readAll());
+        existingSet.addAll(productDtos); // 중복 제거 후 추가
 
-            if (!isDuplicated) {
-                redissonClientSortedSet.add(inMemoryProductDto);
-            }
-        }
+        redissonClientSortedSet.addAll(existingSet); // 중복 제거된 데이터 삽입
 
-        log.info("redissonClientSortedSet size: {}", redissonClientSortedSet.size());
+        log.info("Redis Popular Product Size={}", redissonClientSortedSet.size());
     }
 
-    public List<InMemoryProductDto> getInMemoryProductDto() {
+    public List<InMemoryProductDto> getProductDtos() {
         RSortedSet<InMemoryProductDto> redissonClientSortedSet = redissonClient.getSortedSet("popularProducts");
         return new ArrayList<>(redissonClientSortedSet);
     }
 
-    public void cancel(InMemoryProductDto cancelProductDto) {
+    /**
+     * Redis에 새로운 Product 등록
+     */
+    public void register(InMemoryProductDto saveProductDto) {
         InMemoryProductDto target = null;
         RSortedSet<InMemoryProductDto> redissonClientSortedSet = redissonClient.getSortedSet("popularProducts");
-        for (InMemoryProductDto memoryProductDto : redissonClientSortedSet) {
-            if (memoryProductDto.getProductId() != cancelProductDto.getProductId()) {
+        for (InMemoryProductDto redisProductDto : redissonClientSortedSet) {
+            if (!Objects.equals(redisProductDto.getProductId(), saveProductDto.getProductId())) {
                 continue;
             }
 
-            target = memoryProductDto;
+            target = redisProductDto;
             break;
+        }
+
+        if (target == null) {
+            redissonClientSortedSet.add(saveProductDto);
+        }
+    }
+
+    /**
+     * Redis 등록 Product의 예약 취소
+     * @param productId
+     * @param cancelCount
+     */
+    public void cancel(Long productId, Integer cancelCount) {
+        InMemoryProductDto target = null;
+        RSortedSet<InMemoryProductDto> redissonClientSortedSet = redissonClient.getSortedSet("popularProducts");
+        for (InMemoryProductDto redisProductDto : redissonClientSortedSet) {
+            if(productId.equals(redisProductDto.getProductId())){
+                target = redisProductDto;
+                break;
+            }
         }
 
         if (target != null) {
             redissonClientSortedSet.remove(target);
-            target.minusReservedQuantity(cancelProductDto.getTotalReservedCount());
+            target.minusReservedQuantity(cancelCount);
             redissonClientSortedSet.add(target);
         }
     }
 
-    public void reserve(InMemoryProductDto saveProductDto) {
+    /**
+     * Redis 등록 Product에 대한 예약
+     * @param productId
+     * @param reserveCount
+     */
+    public void reserve(Long productId, Integer reserveCount) {
         InMemoryProductDto target = null;
         RSortedSet<InMemoryProductDto> redissonClientSortedSet = redissonClient.getSortedSet("popularProducts");
-        for (InMemoryProductDto memoryProductDto : redissonClientSortedSet) {
-            if (!Objects.equals(memoryProductDto.getProductId(), saveProductDto.getProductId())) {
-                continue;
+        for (InMemoryProductDto redisProductDto : redissonClientSortedSet) {
+            if (productId.equals(redisProductDto.getProductId())) {
+                target = redisProductDto;
+                break;
             }
-
-            target = memoryProductDto;
-            break;
         }
 
         if (target != null) {
             redissonClientSortedSet.remove(target);
-            target.addReservedQuantity(saveProductDto.getTotalReservedCount());
+            target.addReservedQuantity(reserveCount);
             redissonClientSortedSet.add(target);
-        } else {
-            redissonClientSortedSet.add(saveProductDto);
         }
     }
 }

--- a/src/main/java/kr/or/connect/reservation/domain/reservation/ReservationService.java
+++ b/src/main/java/kr/or/connect/reservation/domain/reservation/ReservationService.java
@@ -4,6 +4,7 @@ import kr.or.connect.reservation.config.exception.CustomException;
 import kr.or.connect.reservation.config.exception.CustomExceptionStatus;
 import kr.or.connect.reservation.domain.member.dao.MemberRepository;
 import kr.or.connect.reservation.domain.member.entity.Member;
+import kr.or.connect.reservation.domain.product.InMemoryPopularProduct;
 import kr.or.connect.reservation.domain.product.InMemoryProductDto;
 import kr.or.connect.reservation.domain.product.RedisPopularProduct;
 import kr.or.connect.reservation.domain.product.dao.ProductRepository;
@@ -40,7 +41,7 @@ public class ReservationService {
 	private final ProductSeatScheduleRepository productSeatScheduleRepository;
 	private final MemberRepository memberRepository;
 
-//	private final InMemoryPopularProduct inMemoryPopularProduct;
+	private final InMemoryPopularProduct inMemoryPopularProduct;
 	private final RedisPopularProduct redisPopularProduct;
 
 	@Transactional
@@ -174,7 +175,7 @@ public class ReservationService {
 				.description(product.getDescription())
 				.releaseDate(product.getReleaseDate())
 				.totalReservedCount(totalReservedQuantity).build();
-		redisPopularProduct.reserve(saveProductDto);
+		inMemoryPopularProduct.reserve(saveProductDto);
 //		inMemoryPopularProduct.reserve(saveProductDto);
 	}
 
@@ -187,7 +188,7 @@ public class ReservationService {
 				.description(product.getDescription())
 				.releaseDate(product.getReleaseDate())
 				.totalReservedCount(totalReservedQuantity).build();
-		redisPopularProduct.cancel(cancelProductDto);
+		inMemoryPopularProduct.cancel(cancelProductDto);
 		// inMemoryPopularProduct.cancel(cancelProductDto);
 	}
 }

--- a/src/test/java/kr/or/connect/reservation/domain/product/RedisPopularProductTest.java
+++ b/src/test/java/kr/or/connect/reservation/domain/product/RedisPopularProductTest.java
@@ -1,0 +1,115 @@
+package kr.or.connect.reservation.domain.product;
+
+import kr.or.connect.reservation.domain.product.dao.ProductSeatScheduleRepository;
+import kr.or.connect.reservation.domain.product.dao.dto.PopularProductDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RSortedSet;
+import org.redisson.api.RedissonClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Sql(scripts = {"classpath:data/data.sql"})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)    // h2에 추가한 sql 초기화
+public class RedisPopularProductTest {
+
+    private static final Logger log = LoggerFactory.getLogger(RedisPopularProductTest.class);
+    @Autowired
+    private ProductSeatScheduleRepository productSeatScheduleRepository;
+    @Autowired
+    private RedissonClient redissonClient;
+    @Autowired
+    private RedisPopularProduct redisPopularProduct;
+
+    @BeforeEach
+    public void setup() {
+        // redis에 테스트 데이터 cache
+        redisPopularProduct.initialize();
+    }
+
+    @Test
+    public void 레디스_상품_조회() {
+        // when
+        List<PopularProductDto> popularProductDtos = productSeatScheduleRepository
+                .findAllPopularProductByReservation();
+
+        List<InMemoryProductDto> productDtos = redisPopularProduct.getProductDtos();
+
+        // then
+        assertThat(productDtos.size()).isEqualTo(popularProductDtos.size());
+    }
+
+    @Test
+    public void 동일제품_등록_방지() {
+        // given
+        InMemoryProductDto saveProduct = new InMemoryProductDto(1000000L, "상품1", "설명1", LocalDate.of(2023, 1, 1), 120, 10);
+        redisPopularProduct.register(saveProduct);
+
+        RSortedSet<InMemoryProductDto> sortedSet = redissonClient.getSortedSet("popularProducts");
+        int originalSize = sortedSet.size();
+
+        // when
+        InMemoryProductDto duplicateProduct = new InMemoryProductDto(1000000L, "상품1", "설명1", LocalDate.of(2023, 1, 1), 120, 10);
+        redisPopularProduct.register(duplicateProduct);
+
+        // then
+        sortedSet = redissonClient.getSortedSet("popularProducts");
+        int duplicateSize = sortedSet.size();
+
+        assertThat(duplicateSize).isEqualTo(originalSize);
+    }
+
+    @Test
+    public void 제품_예약_레디스_반영() {
+        // given
+        InMemoryProductDto productDto = redisPopularProduct.getProductDtos().stream()
+                .filter(v -> v.getProductId().equals(1L))
+                .findFirst().get();
+        int originalReservationCount = productDto.getTotalReservedCount();
+
+        // when: 새로운 상품 예약 호출
+        int addReservedCount = 5;
+        redisPopularProduct.reserve(productDto.getProductId(), addReservedCount);
+
+        // then
+        InMemoryProductDto resultProductDto = redisPopularProduct.getProductDtos().stream()
+                .filter(v -> v.getProductId().equals(1L))
+                .findFirst().get();
+
+        assertThat(resultProductDto.getTotalReservedCount())
+                .isEqualTo(originalReservationCount + addReservedCount);
+    }
+
+    @Test
+    public void 제품_예약_취소_레디스반영() {
+        // given
+        InMemoryProductDto productDto = redisPopularProduct.getProductDtos().stream()
+                .filter(v -> v.getProductId().equals(1L))
+                .findFirst().get();
+        int originalReservationCount = productDto.getTotalReservedCount();
+
+        // when: 상품 예약 1건 취소 호출
+        int cancelReservedCount = 1;
+        redisPopularProduct.cancel(productDto.getProductId(), cancelReservedCount);
+
+        // then
+        InMemoryProductDto resultProductDto = redisPopularProduct.getProductDtos().stream()
+                .filter(v -> v.getProductId().equals(1L))
+                .findFirst().get();
+
+        assertThat(resultProductDto.getTotalReservedCount())
+                .isEqualTo(originalReservationCount - cancelReservedCount);
+    }
+}

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -21,3 +21,7 @@ spring.jpa.properties.hibernate.format_sql=true
 # Redis 설정
 spring.data.redis.host=localhost
 spring.data.redis.port=6379
+
+# test sql 문 로그
+#logging.level.org.springframework.jdbc.datasource.init.ScriptUtils=DEBUG
+#logging.level.org.springframework.jdbc.datasource.init.DataSourceInitializer=DEBUG


### PR DESCRIPTION
- InMemoryProductDto의 중복 방지를 위한 비교를 위해 hashCode와 equals를 오버라이드
- Redis 초기화 전, 기존 캐시 데이터 삭제 처리
- RedisPopularProduct 테스트 코드 재작성