### PR TITLE
[Fix] 무중단 배포 중 쉬는 profile 동작 수정

### DIFF
--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -5,7 +5,6 @@ function find_idle_profile() {
     RESPONSE_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost/profile)
 
     if [[ ${RESPONSE_CODE} -ge 400 ]]; then
-      echo "> ERROR Response Code ge 400"
       # 400 보다 크면 에러
       CURRENT_PROFILE="real2"
     else


### PR DESCRIPTION
- 만약 동작 중인 was가 없을 때 에러 출력으로 인해 잘못된 데이터가 전달됨.
- 400에러 시 다른 에러 출력하지 않도록 수정